### PR TITLE
<< is deprecated, we should be using .add

### DIFF
--- a/lib/spam_email.rb
+++ b/lib/spam_email.rb
@@ -10,7 +10,7 @@ class SpamEmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if SpamEmail.blacklisted?(value)
       message = (options[:message] || I18n.t(:blacklisted, scope: 'spam_email.validations.email'))
-      record.errors[attribute] << message
+      record.errors.add(attribute, :blacklist, message: message)
     end
   end
 end

--- a/spec/spam_email_validator_spec.rb
+++ b/spec/spam_email_validator_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe SpamEmailValidator do
   record_class = Class.new do
     include ActiveModel::Validations
+
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "temp_record")
+    end
+
     attr_accessor :email
     validates :email, :spam_email => true
   end


### PR DESCRIPTION
I was checking newrelic and it's hard to see if this spam gem is blocking anything. One of the reason is they're using << to add the errors instead of using .add.

If we use `<<` `errors.details` will be blank.

https://github.com/freeletics/core-user-rails/blob/4c4ddb5affc74c7a2ed4303d703b8005fa295c85/app/controllers/application_controller.rb#L18

With `.add`, `errors.details` will look like this: `@details={:email=>[{:error=>:blacklist}]}`

Gem specs are passing, also tested on core-user, specs are passing there as well
