### PR TITLE
Unblock qa.team domain from list

### DIFF
--- a/lib/spam_email/blacklist.rb
+++ b/lib/spam_email/blacklist.rb
@@ -10521,7 +10521,7 @@ module SpamEmail
       'q8cbwendy.com',
       'q9byhh.us',
       'q9yepn.us',
-      'qa.team',
+      # 'qa.team',
       'qaaw.ga',
       'qacmemphis.com',
       'qacquirep.com',


### PR DESCRIPTION
Our test.io users are using the qa.team domain for testing. With this PR
we want to unblock them while we introduce the spam_email functionality
in Core User.